### PR TITLE
Add security/keepassx

### DIFF
--- a/security/keepassx/Makefile
+++ b/security/keepassx/Makefile
@@ -1,0 +1,34 @@
+# Created by: Sergey Skvortsov <skv@protey.ru>
+# $FreeBSD$
+
+PORTNAME=	KeePassX
+PORTVERSION=	0.4.3
+PORTREVISION=	1
+CATEGORIES=	security
+MASTER_SITES=	SF/${PORTNAME:tl}/${PORTNAME}/${PORTVERSION}/
+DISTNAME=	${PORTNAME:tl}-${PORTVERSION}
+
+MAINTAINER=	swills@FreeBSD.org
+COMMENT=	Cross Platform Password Manager
+
+RUN_DEPENDS=	update-mime-database:${PORTSDIR}/misc/shared-mime-info
+
+DATADIR=	${PREFIX}/share/${PORTNAME:tl}
+
+USE_QT4=	qmake_build moc_build uic_build qt3support_build rcc_build \
+		corelib gui xml
+HAS_CONFIGURE=	yes
+USE_XORG=	xt inputproto xtst xrender xrandr xfixes xcursor\
+		xext x11 sm ice xi
+MAKE_JOBS_SAFE=	yes
+
+do-configure:
+	@cd ${WRKSRC} && ${SETENV} ${CONFIGURE_ENV} \
+		${QMAKE} -unix PREFIX=${PREFIX} \
+		INCLUDEPATH+=${LOCALBASE}/include LIBS+=-L${LOCALBASE}/lib \
+		keepassx.pro
+
+post-install:
+	-@update-mime-database ${LOCALBASE}/share/mime
+
+.include <bsd.port.mk>

--- a/security/keepassx/distinfo
+++ b/security/keepassx/distinfo
@@ -1,0 +1,2 @@
+SHA256 (keepassx-0.4.3.tar.gz) = cd901a0611ce57e62cf6df7eeeb1b690b5232302bdad8626994eb54adcfa1e85
+SIZE (keepassx-0.4.3.tar.gz) = 1368766

--- a/security/keepassx/files/patch-src__crypto__aes_endian.h
+++ b/security/keepassx/files/patch-src__crypto__aes_endian.h
@@ -1,0 +1,11 @@
+--- ./src/crypto/aes_endian.h.orig	2013-06-08 15:10:48.311186000 +0900
++++ ./src/crypto/aes_endian.h	2013-06-08 15:11:06.040949000 +0900
+@@ -34,7 +34,7 @@
+ /* Include files where endian defines and byteswap functions may reside */
+ #if defined( __sun )
+ #  include <sys/isa_defs.h>
+-#elif defined( __FreeBSD__ ) || defined( __OpenBSD__ ) || defined( __NetBSD__ )
++#elif defined( __FreeBSD__ ) || defined(__DragonFly__) || defined( __OpenBSD__ ) || defined( __NetBSD__ )
+ #  include <sys/endian.h>
+ #elif defined( BSD ) && ( BSD >= 199103 ) || defined( __APPLE__ ) || \
+       defined( __CYGWIN32__ ) || defined( __DJGPP__ ) || defined( __osf__ )

--- a/security/keepassx/pkg-descr
+++ b/security/keepassx/pkg-descr
@@ -1,0 +1,9 @@
+KeePassX is a free/open-source password manager or safe which helps you
+to manage your passwords in a secure way.  You can put all your
+passwords in one database, which is locked with one master key or a
+key-disk.  So you only have to remember one single master password or
+insert the key-disk to unlock the whole database.  The databases are
+encrypted using the best and most secure encryption algorithms currently
+known (AES and Twofish).
+
+WWW: http://www.keepassx.org

--- a/security/keepassx/pkg-plist
+++ b/security/keepassx/pkg-plist
@@ -1,0 +1,108 @@
+bin/keepassx
+share/applications/keepassx.desktop
+%%DATADIR%%/i18n/keepassx-de_DE.qm
+%%DATADIR%%/i18n/keepassx-es_ES.qm
+%%DATADIR%%/i18n/keepassx-fi_FI.qm
+%%DATADIR%%/i18n/keepassx-fr_FR.qm
+%%DATADIR%%/i18n/keepassx-gl_ES.qm
+%%DATADIR%%/i18n/keepassx-hu_HU.qm
+%%DATADIR%%/i18n/keepassx-it_IT.qm
+%%DATADIR%%/i18n/keepassx-ja_JP.qm
+%%DATADIR%%/i18n/keepassx-nb_NO.qm
+%%DATADIR%%/i18n/keepassx-nl_NL.qm
+%%DATADIR%%/i18n/keepassx-pl_PL.qm
+%%DATADIR%%/i18n/keepassx-pt_PT.qm
+%%DATADIR%%/i18n/keepassx-ru_RU.qm
+%%DATADIR%%/i18n/keepassx-sk_SK.qm
+%%DATADIR%%/i18n/keepassx-sr_RS.qm
+%%DATADIR%%/i18n/keepassx-tr_TR.qm
+%%DATADIR%%/i18n/keepassx-uk_UA.qm
+%%DATADIR%%/i18n/keepassx-zh_CN.qm
+%%DATADIR%%/i18n/qt_fi.qm
+%%DATADIR%%/i18n/qt_gl_ES.qm
+%%DATADIR%%/i18n/qt_hu.qm
+%%DATADIR%%/i18n/qt_it.qm
+%%DATADIR%%/i18n/qt_nl.qm
+%%DATADIR%%/i18n/qt_sr.qm
+%%DATADIR%%/i18n/qt_tr.qm
+%%DATADIR%%/icons/alarmclock.png
+%%DATADIR%%/icons/appsettings.png
+%%DATADIR%%/icons/autotype.png
+%%DATADIR%%/icons/bookmark.png
+%%DATADIR%%/icons/bookmark_add.png
+%%DATADIR%%/icons/bookmark_del.png
+%%DATADIR%%/icons/bookmark_edit.png
+%%DATADIR%%/icons/bookmark_folder.png
+%%DATADIR%%/icons/bookmark_this.png
+%%DATADIR%%/icons/clientic.png
+%%DATADIR%%/icons/clock.png
+%%DATADIR%%/icons/cloneentry.png
+%%DATADIR%%/icons/copypwd.png
+%%DATADIR%%/icons/copyusername.png
+%%DATADIR%%/icons/dbsearch.png
+%%DATADIR%%/icons/dbsettings.png
+%%DATADIR%%/icons/delete.png
+%%DATADIR%%/icons/deleteentry.png
+%%DATADIR%%/icons/deletegroup.png
+%%DATADIR%%/icons/dice.png
+%%DATADIR%%/icons/document.png
+%%DATADIR%%/icons/down.png
+%%DATADIR%%/icons/editentry.png
+%%DATADIR%%/icons/editgroup.png
+%%DATADIR%%/icons/exit.png
+%%DATADIR%%/icons/expired.png
+%%DATADIR%%/icons/fileclose.png
+%%DATADIR%%/icons/filedelete.png
+%%DATADIR%%/icons/filenew.png
+%%DATADIR%%/icons/fileopen.png
+%%DATADIR%%/icons/filesave.png
+%%DATADIR%%/icons/filesaveas.png
+%%DATADIR%%/icons/filesavedisabled.png
+%%DATADIR%%/icons/generator.png
+%%DATADIR%%/icons/go-home.png
+%%DATADIR%%/icons/go-next.png
+%%DATADIR%%/icons/go-previous.png
+%%DATADIR%%/icons/groupsearch.png
+%%DATADIR%%/icons/help.png
+%%DATADIR%%/icons/help_about.png
+%%DATADIR%%/icons/i18n.png
+%%DATADIR%%/icons/keepassx.png
+%%DATADIR%%/icons/keepassx_large.png
+%%DATADIR%%/icons/keepassx_locked.png
+%%DATADIR%%/icons/keepassx_small.png
+%%DATADIR%%/icons/key.png
+%%DATADIR%%/icons/lock.png
+%%DATADIR%%/icons/manual.png
+%%DATADIR%%/icons/newentry.png
+%%DATADIR%%/icons/newgroup.png
+%%DATADIR%%/icons/ok.png
+%%DATADIR%%/icons/openurl.png
+%%DATADIR%%/icons/pwd_hide.png
+%%DATADIR%%/icons/pwd_show.png
+%%DATADIR%%/icons/restore.png
+%%DATADIR%%/icons/search.png
+%%DATADIR%%/icons/swap.png
+%%DATADIR%%/icons/templates.png
+%%DATADIR%%/icons/text_block.png
+%%DATADIR%%/icons/text_bold.png
+%%DATADIR%%/icons/text_center.png
+%%DATADIR%%/icons/text_italic.png
+%%DATADIR%%/icons/text_left.png
+%%DATADIR%%/icons/text_right.png
+%%DATADIR%%/icons/text_under.png
+%%DATADIR%%/icons/trashcan.png
+%%DATADIR%%/icons/up.png
+%%DATADIR%%/license.html
+share/mime/packages/keepassx.xml
+share/mimelnk/application/x-keepass.desktop
+share/pixmaps/keepassx.xpm
+@dirrm %%DATADIR%%/icons
+@dirrm %%DATADIR%%/i18n
+@dirrm %%DATADIR%%
+@dirrmtry share/mimelnk/application
+@dirrmtry share/mimelnk
+@dirrmtry share/mime/packages
+@dirrmtry share/mime
+@dirrmtry share/applications
+@exec %%LOCALBASE%%/bin/update-mime-database %D/share/mime
+@unexec %%LOCALBASE%%/bin/update-mime-database %D/share/mime


### PR DESCRIPTION
This adds security/keepassx from the FreeBSD repository, with 2 changes:

a) Fixes to the makefile so it works with bmake (previously used FreeBSD-make specific variable substitutions)
b) A one-line patch that is necessary to make the package build on Dragonfly
