### PR TITLE
xf86-video-nv: ignore check due to vgapci as well

### DIFF
--- a/x11-drivers/xf86-video-nv/files/patch-src-nv_driver.c
+++ b/x11-drivers/xf86-video-nv/files/patch-src-nv_driver.c
@@ -4,7 +4,7 @@
                        NVGetPCIXpressChip(dev) : dev->vendor_id << 16 | dev->device_id;
      const char *name = xf86TokenToString(NVKnownChipsets, id);
  
-+#ifndef __FreeBSD__
+#if !!defined(__FreeBSD__) && !defined(__DragonFly__)
 +    /* FreeBSD always has vgapci driver attached.  */
      if (pci_device_has_kernel_driver(dev)) {
          xf86DrvMsg(0, X_ERROR,


### PR DESCRIPTION
I think vgapci is always bound to the pci as well in DragonFly